### PR TITLE
Core: More robust JLink detection; support WolframEngine on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,19 @@ The canonical pronunciation of Clojuratica starts with Clojure and rhymes with e
 
 ### Prerequisites:
 
+#### Clojure
+
 First, if you haven't already, install the [Clojure CLI toolchain](https://clojure.org/guides/getting_started) (homebrew is a great way to do this if you're on Mac or Linux, but you can just as easily use the install scripts if you prefer).
+
+#### Mathematica or Wolfram Engine
+
 Next, obviously, you'll need to ensure that you have Wolfram Language or Mathematica installed.
+
+Normally, it should be detected and loaded automatically, when you require the `clojuratica.core` namespace. Watch stdout for a message like:
+
+> Adding path to classpath: /Applications/Wolfram Engine.app/Contents/Resources/Wolfram Player.app/Contents/SystemFiles/Links/JLink/JLink.jar
+
+However, sometimes Wolframite may fail be find the correct path automatically and need your help. You can set the `MATHEMATICA_INSTALL_PATH` or `WOLFRAM_INSTALL_PATH` environment variables or Java system properties (the latter takes priority) to point to the correct location.
 
 ### Getting started
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.10.3"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         clj-commons/pomegranate {:mvn/version "1.2.1"}}
  :aliases {:dev {:extra-paths ["dev" "test"]
                  :jvm-opts ["-Djdk.attach.allowAttachSelf" ]
@@ -10,4 +10,5 @@
                               aerial.hanami/aerial.hanami {:mvn/version "0.15.1"}
                               io.github.nextjournal/clerk {:mvn/version "0.3.233"}
                               borkdude/edamame {:mvn/version "0.0.19"}
-                              clj-http/clj-http {:mvn/version "3.11.0"}}}}}
+                              clj-http/clj-http {:mvn/version "3.11.0"}
+                              org.slf4j/slf4j-simple {:mvn/version "2.0.9"}}}}}

--- a/src/clojuratica/core.clj
+++ b/src/clojuratica/core.clj
@@ -48,7 +48,7 @@
 
 (defonce kernel-link-atom (atom nil))
 
-(defn kernel-link-opts [{:keys [platform mathlink-path]}]
+(defn kernel-link-opts ^"[Ljava.lang.String;" [{:keys [platform mathlink-path]}]
   ;; See https://reference.wolfram.com/language/JLink/ref/java/com/wolfram/jlink/MathLinkFactory.html#createKernelLink(java.lang.String%5B%5D)
   ;; and https://reference.wolfram.com/language/tutorial/RunningTheWolframSystemFromWithinAnExternalProgram.html for the options
   (into-array String ["-linkmode" "launch"
@@ -172,7 +172,7 @@
 
 (defn ->clj! [s]
   {:flags [:no-evaluate]}
-  (wl (list 'quote s) {:flags [:no-evaluate]}))
+  (eval (list 'quote s) {:flags [:no-evaluate]}))
 
 (defn ->wl!
   "Convert clojure forms to mathematica Expr.

--- a/src/clojuratica/jlink.clj
+++ b/src/clojuratica/jlink.clj
@@ -48,8 +48,8 @@
   (and path (.exists (io/file path))))
 
 (defn detect-available-installation [platform]
-  (->> (get paths platform)
-       vals
+  (->> (-> (get paths platform)
+           ((juxt :mathematica :wolfram-engine)))  ; prefer Mathematica to Wolfram, it is presumably more capable
        (filter (comp file-exists? :path))
        first))
 
@@ -142,8 +142,6 @@
 (add-jlink-to-classpath!)
 
 (comment
-  (base-path :macos)
-  (base-path :linux)
 
   (get-jlink-path :macos)
   (get-jlink-path :linux)

--- a/src/clojuratica/jlink.clj
+++ b/src/clojuratica/jlink.clj
@@ -149,8 +149,10 @@
 
   (get-jlink-path :macos)
   (get-jlink-path :linux)
+  (get-jlink-path :windows)
 
   (get-mathlink-path :macos)
   (get-mathlink-path :linux)
+  (get-mathlink-path :windows)
 
   (platform-paths :linux))


### PR DESCRIPTION
Replace bunch of hardcoded, interrelated paths with a map of platform -> engine/mathematica -> (base) path, mathlink suffix. Make sure we support both Wolfram Engine and Mathematica on all 3 paltforms (though I couldn't verify all the paths).

Auto-detect, whether we have a Math. or W.E. installation available.

Support system properties in addition to env. vars for setting paths.

More informative error messages.

Upgrade to Clojure 1.11 -> parse-long

Dev: Add slf4j-simple so that when we use clojure.tools.logging, we will see some output.