### PR TITLE
load-all-symbols' vars should just be symbols => no double eval

### DIFF
--- a/DEV-DOCS.md
+++ b/DEV-DOCS.md
@@ -17,13 +17,13 @@
 
 ## TODO
 
-[ ] FIXME: `load-all-symbols` should make each symbol into a var that just contains a symbol, and requires an explicit call to `wl/eval`. Justification: 1) wrapping each symbol with a fn breaks expression that use them as values, such as `(Plus 1 Pi)` (we'd try to add 1 to a clojure lambda fn), 2) Nested expressions result in multiple calls to Wolfram: e.g. `(Plus 1 (Plus 2 3))` would evaluate _two_ expressions: `Plus[2, 3]]` and `Plus[1, 5]]`, while we only want to evaluate once. Perhaps keep a fn to enable explicit turning of selected vars into functions? 
-[ ] Add tests for parse, convert, key fns
-[x] Rename namespaces, docs to Wolframite
-[x] Replace uses of wl/wl with wl/eval (= standardize on a single, understandable one) - in demo etc
-[x] Explore, Leverage for docs dev/explainer.clj, notebook.demo 
-[x] Get rid of the custom-parse flag requirement
-[ ] Get better errors from the Kernel: Running `(First (WolframLanguageData))` when offline returns `(Entity "WolframLanguageSymbol" "$Aborted")` while in W.Eng. it also prints a bunch of useful error info; can we get hold of it? Aslo, should we turn the $Aborted into an exception?! See below:
+* [ ] Add tests for parse, convert, key fns
+* [x] FIXME: `load-all-symbols` should make each symbol into a var that just contains a symbol, and requires an explicit call to `wl/eval`. Justification: 1) wrapping each symbol with a fn breaks expression that use them as values, such as `(Plus 1 Pi)` (we'd try to add 1 to a clojure lambda fn), 2) Nested expressions result in multiple calls to Wolfram: e.g. `(Plus 1 (Plus 2 3))` would evaluate _two_ expressions: `Plus[2, 3]]` and `Plus[1, 5]]`, while we only want to evaluate once. Perhaps keep a fn to enable explicit turning of selected vars into functions? 
+* [x] Rename namespaces, docs to Wolframite
+* [x] Replace uses of wl/wl with wl/eval (= standardize on a single, understandable one) - in demo etc
+* [x] Explore, Leverage for docs dev/explainer.clj, notebook.demo 
+* [x] Get rid of the custom-parse flag requirement
+* [ ] Get better errors from the Kernel: Running `(First (WolframLanguageData))` when offline returns `(Entity "WolframLanguageSymbol" "$Aborted")` while in W.Eng. it also prints a bunch of useful error info; can we get hold of it? Aslo, should we turn the $Aborted into an exception?! See below:
 
 ```wolram
 In[6]:= First[WolframLanguageData[]]                                                              
@@ -66,10 +66,7 @@ Subtract::argr: Subtract called with 1 argument; 2 arguments are expected.
 * What are `defaults/clojure-scope-aliases` about?
 * How to load .wl file into a REPL? (Thomas may know)
 ```
- 
- 
- 
- 
+
 ### Performance
 
 * `graphics/show!` seems pretty slow - multiple seconds to minutes to render a result
@@ -107,9 +104,7 @@ Modify how Wolfram response is parsed into Clojure data - override `clojuratica.
 
 ### Various
 
-* `wl/clj-intern` - intern a Wolfram function (e.g. `'Plus`) into a clj ns
 * `wl/load-all-symbols` - intern all Wolf. symbols into the given ns
-
 * `(parse/parse-fn sym opts)` - return a "proxy fn", which will invoke a Wolfram fn of the given name, transforming its arguments from Clojure data to Wolfram expressions and the opposite on the result.
-** Powered by `clojuratica.base.cep/cep`, the convert-eval-parse fn
+  * Powered by `clojuratica.base.cep/cep`, the convert-eval-parse fn
 * Naming of options: the convention for opts passed through the pipeline si that the keyword namespace would indicate the stage of the pipeline (convert, parse, eval).

--- a/dev/demo.clj
+++ b/dev/demo.clj
@@ -81,16 +81,6 @@
 
 (W:Plus 1 2 3) ; ... and call it
 
-(wl/clj-intern 'Plus {}) ; a simpler way to do the same -> fn Plus in this ns
-
-(run! wl/clj-intern ['Dot 'Plus])
-
-(comment
-  ;; Call interned Wl functions:
-  (Dot [1 2 3] [4 5 6])
-  (Plus 1 2 3)
-  (Plus [1 2] [3 4]))
-
 (def greetings
   (wl/eval
    '(Function [x] (StringJoin "Hello, " x "! This is a Mathematica function's output."))))
@@ -139,12 +129,6 @@
 
 (wl/eval '(WolframAlpha "number of moons of Saturn" "Result"))
 
-;; * Issues
-;; - WL syntactic sugar
-;; FIXME: doesn't work
-(WL @(a b c d))
-
 ;; - more interesting examples...
 
-;; FIXME: some loopiness and NPE
-(wl/eval '(TextStructure "You can do so much with the Wolfram Language." "ConstituentGraphs"))
+(wl/eval '(TextStructure "You can do so much with the Wolfram Language." "ConstituentGraphs")) ; returns a graph as data

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -16,10 +16,10 @@
 
   ;; Use eval with a quoted Wolfram-as-clojure-data expression (`Fn[..]` becoming `(Fn ..)`):
   (wl/eval '(Dot [1 2 3] [4 5 6])) ; Wolfram: `Dot[{1, 2, 3}, {4, 5, 6}]]`
-  (Dot [1 2 3] [4 5 6]) ; We have loaded all symbols as Clojure fns and thus can run this directly
+  (wl/eval (Dot [1 2 3] [4 5 6])) ; We have loaded all symbols as Clojure fns and thus can run this directly
 
   (wl/eval '(N Pi 20))
-  (N 'Pi 20) ; Beware: Pi must still be quoted, it is not a fn
+  (wl/eval (N 'Pi 20)) ; Beware: Pi must still be quoted, it is not a fn
 
   ;;
   ;; Built-in documentation:

--- a/dev/notebook/demo.clj
+++ b/dev/notebook/demo.clj
@@ -1,5 +1,5 @@
 (ns notebook.demo
-  (:require [wolframite.core  :refer [load-all-symbols wl] :as w]
+  (:require [wolframite.core  :refer [eval] :as w]
             [wolframite.base.convert :as cv]
             [wolframite.jlink :as jlink]
             [wolframite.lib.helpers :refer [help!]]
@@ -66,7 +66,7 @@
   ((last (last img)) "URL"))
 
 (def movie-ents
-   (wl
+   (eval
     '(Map (Function [m] [m (m "Image")])
           (Keys
            (Take

--- a/src/wolframite/base/parse.clj
+++ b/src/wolframite/base/parse.clj
@@ -138,7 +138,9 @@
   "Return a function that invokes the Wolfram expression `expr` (typically just a symbol naming a fn),
   converting any arguments given to it from Clojure to Wolfram and does the opposite conversion on the
   result.
-  Ex.: `((parse/parse-fn 'Plus {:kernel/link @wl/kernel-link-atom}) 1 2) ; => 3`"
+  Ex.: `((parse/parse-fn 'Plus {:kernel/link @wl/kernel-link-atom}) 1 2) ; => 3`
+
+  Beware: Nesting such fns would result in multiple calls to Wolfram, which is inefficient. Prefer wl/eval in such cases."
   [expr opts]
   (fn [& args]
     (let [cep-fn (requiring-resolve `wolframite.base.cep/cep)]

--- a/src/wolframite/core.clj
+++ b/src/wolframite/core.clj
@@ -175,7 +175,7 @@
         (def Plus (wolfram-fn 'Plus))
         (def Pi (wolfram-fn 'Pi))
         (Plus 1 2) ; => (Plus 1 2)
-        (Plus 1 Pi) ; => (Plus 1 Pi)) ; TODO Add the fn -> sym processing also to wl/eval so that it works e.g. also for (+ 1 Pi) etc ?
+        (Plus 1 Pi)) ; => (Plus 1 Pi) ; TODO Add the fn -> sym processing also to wl/eval so that it works e.g. also for (+ 1 Pi) etc ?
 
   ([wl-fn-sym]
    (clj-intern wl-fn-sym {}))

--- a/src/wolframite/core.clj
+++ b/src/wolframite/core.clj
@@ -170,6 +170,13 @@
   ;; On interning: parse/parse-fn essentially creates a "proxy" function of the same name as a Wolfram function, which will convert the passed-in Clojure expression to the JLink `Expr`,
   ;; send it to a Wolfram Kernel for evaluation, and parse the result back into Clojure data. Beware that `wl/load-all-symbols` may take 10s of seconds - some minutes.
 
+  ;; FIXME: Use something like this, where at val position we get a symbol (or we do once we process it) and at fn position we get a fn that returns a list of symbs
+  #_(do (defn- wolfram-fn [sym] ^{::wolfram-sym sym} (fn wolf-fn [& args] (apply list sym (->> args (map #(or (when (fn? %) (-> % meta ::wolfram-sym)) %))))))
+        (def Plus (wolfram-fn 'Plus))
+        (def Pi (wolfram-fn 'Pi))
+        (Plus 1 2) ; => (Plus 1 2)
+        (Plus 1 Pi) ; => (Plus 1 Pi)) ; TODO Add the fn -> sym processing also to wl/eval so that it works e.g. also for (+ 1 Pi) etc ?
+
   ([wl-fn-sym]
    (clj-intern wl-fn-sym {}))
   ([wl-fn-sym {:intern/keys [ns-sym extra-meta] :as opts}]

--- a/src/wolframite/impl/intern.clj
+++ b/src/wolframite/impl/intern.clj
@@ -1,0 +1,52 @@
+(ns wolframite.impl.intern
+  "Interning of Wolfram symbols as Clojure vars, for convenience."
+  (:import (clojure.lang IMeta)))
+
+(defn interned-var-val->symbol
+  "Turns the value of an [[clj-intern]]-ed Wolfram symbols into said symbol, if possible - otherwise, returns nil.
+  Ex.:
+  ```clj
+  (clj-intern 'Plus {})
+  Plus ; => #function[wolframite...]
+  (interned-var-val->symbol Plus) ; => 'Plus
+  ```"
+  [maybe-fn]
+  (when (instance? IMeta maybe-fn)
+    (-> maybe-fn meta ::wolfram-sym)))
+
+(defn- wolfram-fn
+  "Turn the wolfram symbol into a metadata-tagged function, which returns a list with
+  the symbol at head, and any arguments as-is. The metadata contains the symbol.
+  Used for exposing Wolfram symbols to Clojure code."
+  [sym]
+  ^{::wolfram-sym sym} (fn wolf-fn [& args]
+                         (apply list sym
+                                (->> args
+                                     (map (some-fn interned-var-val->symbol
+                                                   ;; I don't think we should ever get to 👇 but better safe than sorry...
+                                                   identity))))))
+
+(defn clj-intern
+  "Finds or creates a var named by the symbol `wl-sym` in the current namespace,
+  which will resolve into a symbol of the same name.
+
+  You can override the target namespace and add additional metadata to the var by
+  setting the appropriate `opts`.
+
+  Ex.:
+  ```clj
+  (clj-intern 'Plus {})
+  (wl/eval (Plus 1 2))
+  ; => 3
+  ```
+
+  See also [[load-all-symbols]]."
+  ([wl-sym]
+   (clj-intern wl-sym {}))
+  ([wl-sym {:intern/keys [ns-sym extra-meta] :as opts}]
+   (let [f (wolfram-fn wl-sym)]
+     (intern (create-ns (or ns-sym (.name *ns*)))
+             (with-meta wl-sym (merge {:clj-intern true}
+                                      extra-meta
+                                      (meta f)))
+             f))))

--- a/src/wolframite/lib/helpers.clj
+++ b/src/wolframite/lib/helpers.clj
@@ -1,5 +1,6 @@
 (ns wolframite.lib.helpers
-  (:require [clojure.java.browse :refer [browse-url]]))
+  (:require [clojure.java.browse :refer [browse-url]]
+            [wolframite.impl.intern :as intern]))
 
 (defn help-link [fn-sym]
   (format "https://reference.wolfram.com/language/ref/%s.html" fn-sym))
@@ -10,14 +11,16 @@
 (defn help!
   "Get web based help for a given symbol or form.
   If a form is given this will operate on all symbols found in the form.
-  By default opens web browser with relevant reference documentation.
+  By default, opens web browser with relevant reference documentation.
   You can pass `return-links true` if you just want URLs."
   [sym-or-form & {:keys [return-links]}]
-  (let [links (cond
-                (symbol? sym-or-form) [(help-link sym-or-form)]
-                (list? sym-or-form)   (map help-link (just-symbols sym-or-form))
+  (let [sym-or-form' (or (intern/interned-var-val->symbol sym-or-form)
+                         sym-or-form)
+        links (cond
+                (symbol? sym-or-form') [(help-link sym-or-form')]
+                (list? sym-or-form') (map help-link (just-symbols sym-or-form'))
                 :else (throw (ex-info "You need to pass `symbol?` or `list?` as argument"
-                                      {:passed-type (type sym-or-form)})))]
+                                      {:passed-type (type sym-or-form')})))]
     (if return-links
       links
       (doseq [l links]

--- a/test/wolframite/core_test.clj
+++ b/test/wolframite/core_test.clj
@@ -16,3 +16,19 @@
 ;;   (testing "translating FROM clj" (is (= "GridGraph[{5, 5}]"
 ;;                                          (wl/clj->wl '(GridGraph [5 5]) {:kernel-link wl/kernel-link
 ;;                                                                          :output-fn str})))))
+
+(deftest load-all-symbols-test
+  (wl/load-all-symbols 'w)
+  (is (= 3
+         (wl/eval (w/Plus 1 2)))
+      "An interned symbol can be used at a function position")
+  (is (= 3
+         (wl/eval (list 'Floor w/Pi)))
+      "An interned symbol can be used at a value position")
+  (is (= -3
+         (wl/eval (w/Floor (w/Plus 1 (w/Minus w/Pi))))
+         (wl/eval '(Floor (Plus 1 (Minus Pi)))))
+      "Interned vars behave properly also when nested few levels deep")
+  (is (= "x+y+z represents a sum of terms."
+         (-> #'w/Plus meta :doc))
+      "Interned vars have docstrings"))

--- a/test/wolframite/core_test.clj
+++ b/test/wolframite/core_test.clj
@@ -23,7 +23,7 @@
          (wl/eval (w/Plus 1 2)))
       "An interned symbol can be used at a function position")
   (is (= 3
-         (wl/eval (list 'Floor w/Pi)))
+         (wl/eval (w/Floor w/Pi)))
       "An interned symbol can be used at a value position")
   (is (= -3
          (wl/eval (w/Floor (w/Plus 1 (w/Minus w/Pi))))


### PR DESCRIPTION
Issue: load-all-symbols produces vars that hold functions, which auto-evaluate (calling Wolfram). Thus, `(Plus 1 (Plus 2 3))` will make 2 calls to Wolfram, instead of one. Moreover, you can't do `(Plus 1 Pi)` b/c Pi is not a symbol and Wolfram won't handle it.

Fix: Drop auto-evaluation and require manual wl/eval call. Ensure that all interned symbols resolve into symbols at value position, and functions that return a list of symbols at fn position. Actually we cheat, we make them fns also at value positions, but before sending to Wolfram, we detect those and turn them back to symbols.