### PR TITLE
Jlink restructure

### DIFF
--- a/dev/kindly_demo.clj
+++ b/dev/kindly_demo.clj
@@ -12,7 +12,7 @@
    [wolframite.core :as wl]
    [wolframite.tools.hiccup :refer [view]]
    [wolframite.base.parse :as parse]
-   [wolframite.jlink]
+   [wolframite.runtime.jlink]
    [scicloj.kindly.v4.kind :as kind]
    [scicloj.kindly.v4.api :as kindly])
   (:import (com.wolfram.jlink MathCanvas KernelLink)
@@ -60,7 +60,6 @@ Note that the Quarto-based target requires the [Quarto CLI](https://quarto.org/d
 
 (W:Plus 1 2 3) ; ... and call it
 
-
 (def greetings
   (wl/eval
    '(Function [x] (StringJoin "Hello, " x "! This is a Mathematica function's output."))))
@@ -69,7 +68,6 @@ Note that the Quarto-based target requires the [Quarto CLI](https://quarto.org/d
 
 (md "## Bidirectional translation
 (Somewhat experimental, especially in the wl->clj direction)")
-
 
 (wl/->clj "GridGraph[{5, 5}]")
 (wl/->wl '(GridGraph [5 5]) {:output-fn str})

--- a/dev/notebook/demo.clj
+++ b/dev/notebook/demo.clj
@@ -1,7 +1,7 @@
 (ns notebook.demo
   (:require [wolframite.core  :refer [eval] :as w]
             [wolframite.base.convert :as cv]
-            [wolframite.jlink :as jlink]
+            [wolframite.runtime.jlink :as jlink]
             [wolframite.lib.helpers :refer [help!]]
             [wolframite.tools.clerk-helper :refer [view]]
             [aerial.hanami.common :as hc]
@@ -14,14 +14,11 @@
             [clojure.string :as str]
             [clojure.repl :refer [doc find-doc apropos]]))
 
-
 ;; # Wolfram Language Graphics
-
 
 ;; ## Numbers
 
 (view '(BarChart (EntityValue (EntityClass "Planet" All) "Radius")))
-
 
 ;; ## Time
 
@@ -44,7 +41,6 @@
                        (Entity "City" ["Boston" "Massachusetts" "UnitedStates"])]
                       "Geodesic")]))
 
-
 ;; ## 3D
 
 (view '(MoleculePlot3D (Molecule "O=C(C1CCC1)S[C@@H]1CCC1(C)C")))
@@ -66,17 +62,17 @@
   ((last (last img)) "URL"))
 
 (def movie-ents
-   (eval
-    '(Map (Function [m] [m (m "Image")])
-          (Keys
-           (Take
-            (Reverse
-             (Sort
-              (DeleteMissing (MovieData
-                              (MovieData ["RandomEntities" 300])
-                              "DomesticBoxOfficeGross"
-                              "EntityAssociation"))))
-            2)))))
+  (eval
+   '(Map (Function [m] [m (m "Image")])
+         (Keys
+          (Take
+           (Reverse
+            (Sort
+             (DeleteMissing (MovieData
+                             (MovieData ["RandomEntities" 300])
+                             "DomesticBoxOfficeGross"
+                             "EntityAssociation"))))
+           2)))))
 
 (nb/html
  [:div.guess-the-movie

--- a/src/wolframite/base/convert.clj
+++ b/src/wolframite/base/convert.clj
@@ -1,6 +1,6 @@
 (ns wolframite.base.convert
   "Convert a Clojure expression into a Wolfram JLink expression"
-  (:require [wolframite.jlink]
+  (:require [wolframite.runtime.jlink]
             [wolframite.lib.options :as options]
             [wolframite.base.express :as express]
             [wolframite.base.expr :as expr]
@@ -52,9 +52,9 @@
 
 (defmethod convert nil [obj _]
   (.getExpr
-    (doto (MathLinkFactory/createLoopbackLink)
-      (.put obj)
-      (.endPacket))))
+   (doto (MathLinkFactory/createLoopbackLink)
+     (.put obj)
+     (.endPacket))))
 
 (defmethod convert :null [_ opts]
   (convert 'Null opts))
@@ -84,7 +84,7 @@
   (cond (simple-matrix? coll opts) (convert (to-array-2d coll) opts)
         (simple-vector? coll opts) (convert (to-array coll) opts)
         :else                      (convert (to-array (map #(if dispatch (convert % opts) %)
-                                                        coll))
+                                                           coll))
                                             opts)))
 
 (defmethod convert :expr [cexpr opts]

--- a/src/wolframite/base/evaluate.clj
+++ b/src/wolframite/base/evaluate.clj
@@ -1,6 +1,6 @@
 (ns wolframite.base.evaluate
   "The core of evaluation: send a converted JLink expression to a Wolfram Kernel for evaluation and return the result."
-  (:require [wolframite.jlink]
+  (:require [wolframite.runtime.jlink]
             [wolframite.lib.options :as options]
             [wolframite.base.convert :as convert]))
 
@@ -40,9 +40,9 @@
        (.getExpr link)))
     (let [opts' (update opts :flags conj :serial) ;; FIXME: make sure this is supposed to be `:serial`, it's what I gather from previous version of the code
           pid-expr (evaluate (convert/convert
-                               (list 'Unique
+                              (list 'Unique
                                      ; Beware: technically, this is an invalid clj symbol due to the slashes:
-                                     (symbol "Wolframite/Concurrent/process")) opts')
+                                    (symbol "Wolframite/Concurrent/process")) opts')
                              opts)]
       ;; FIXME: debug log: "pid-expr:"
       (evaluate (convert/convert (list '= pid-expr (list 'ParallelSubmit expr)) opts') opts)

--- a/src/wolframite/base/expr.clj
+++ b/src/wolframite/base/expr.clj
@@ -1,5 +1,5 @@
 (ns wolframite.base.expr
-  (:require [wolframite.jlink])
+  (:require [wolframite.runtime.jlink])
   (:import [com.wolfram.jlink Expr]))
 
 (defn head-str [expr]

--- a/src/wolframite/base/parse.clj
+++ b/src/wolframite/base/parse.clj
@@ -1,7 +1,7 @@
 (ns wolframite.base.parse
   "Translate a jlink.Expr returned from an evaluation into Clojure data"
   (:require
-   [wolframite.jlink]
+   [wolframite.runtime.jlink]
    [wolframite.lib.options :as options]
    [wolframite.base.expr :as expr]
    [clojure.string :as str])
@@ -33,7 +33,7 @@
 (defn custom-parse-dispatch [expr {:keys [parse/custom-parse-symbols]}]
   (let [head (symbol (expr/head-str expr))]
     (when-not
-        (and (seq custom-parse-symbols) (not (contains? (set custom-parse-symbols) head)))
+     (and (seq custom-parse-symbols) (not (contains? (set custom-parse-symbols) head)))
       head)))
 
 (defn atom? [expr]
@@ -181,7 +181,6 @@
     (simple-vector-type expr)                        (parse-simple-vector expr nil opts)
     (simple-matrix-type expr)                        (parse-simple-matrix expr nil opts)
     :else                                            (parse-complex-list expr opts)))
-
 
 (ns-unmap *ns* 'custom-parse)
 (defmulti custom-parse

--- a/src/wolframite/jlink.clj
+++ b/src/wolframite/jlink.clj
@@ -1,5 +1,7 @@
 (ns wolframite.jlink
   "
+  DEPRECATED: Use runtime.jlink now.
+
   'J/Link' integrates the Wolfram Language and Java (https://reference.wolfram.com/language/JLink/tutorial/Introduction.html): providing a two-way bridge between the two.
 
   Accordingly, this namespace manages the J/Link connection in order to extend this bridge to the Clojure language. As such, this namespace is crucial to the whole wolframite project.
@@ -191,24 +193,25 @@
              first)
          (throw (ex-info (str "Could not find a Wolfram executable at the given base path. We looked in these places: " (seq options) ".") {:paths options}))))))
 
-(defn add-jlink-to-classpath!
-  "Tries and 'throws' otherwise."
-  ([]
-   (add-jlink-to-classpath! (detect-platform)))
-  ([os]
-   (let [path (path--jlink os)]
-     (when-not (fs/exists? path)
-       (throw (ex-info (str "Unable to find JLink jar at the expected path " path
-                            " Consider setting one of the supported environment variables;"
-                            " currently: " (into [] (supplied-paths)) ".")
-                       {:platform os
-                        :path path
-                        :env (supplied-paths)})))
-     (println (str "=== Adding path to classpath:" path " ==="))
-     (pom/add-classpath path))))
+;; DEPRECATED: Commenting out temporarily
+;; (defn add-jlink-to-classpath!
+;;   "Tries and 'throws' otherwise."
+;;   ([]
+;;    (add-jlink-to-classpath! (detect-platform)))
+;;   ([os]
+;;    (let [path (path--jlink os)]
+;;      (when-not (fs/exists? path)
+;;        (throw (ex-info (str "Unable to find JLink jar at the expected path " path
+;;                             " Consider setting one of the supported environment variables;"
+;;                             " currently: " (into [] (supplied-paths)) ".")
+;;                        {:platform os
+;;                         :path path
+;;                         :env (supplied-paths)})))
+;;      (println (str "=== Adding path to classpath:" path " ==="))
+;;      (pom/add-classpath path))))
 
 ;; ==================================================
 ;; ENTRY POINT
 ;; ==================================================
-(add-jlink-to-classpath!)
+;; (add-jlink-to-classpath!)
 ;; ==================================================

--- a/src/wolframite/runtime/defaults.clj
+++ b/src/wolframite/runtime/defaults.clj
@@ -28,7 +28,7 @@
 (def base-aliases
   {'do   'CompoundExpression
    '=    'Set
-   '..=  'SetDelayed ;; TODO: Document this exception. Presumably not := because of clojure's keywords
+   '..=  'SetDelayed ;; TODO: Document this exception. Presumably not := because of clojure's keywords. It's actually nicer in a way though, because an (almost) ellipsis implies a delay!
    '=.   'Unset
    '->   'Rule
    '..>  'RuleDelayed

--- a/src/wolframite/runtime/jlink.clj
+++ b/src/wolframite/runtime/jlink.clj
@@ -1,0 +1,64 @@
+(ns wolframite.runtime.jlink
+  "
+  'J/Link' integrates the Wolfram Language and Java (https://reference.wolfram.com/language/JLink/tutorial/Introduction.html): providing a two-way bridge between the two.
+
+  Accordingly, this namespace manages the J/Link connection in order to extend this bridge to the Clojure language
+
+  WARNING: This namespace is (currently) side effecting, and is required for many of the files in this project to compile.
+
+  NOTE:
+
+  - Paths which are not absolute should not start with a '/'. In general, we should be aiming to comply with the babashka.fs standards.
+  - Pomegranate is used to dynamically add the Wolfram Language / Mathematica JLink jar to the JVM classpath.
+  - Because many of the namespaces in this project either import or reference the jlink classes, it's necessary to have loaded this namespace before those namespaces will compile. Thus, you'll see this ns required, but unused, across the codebase. This is to get around that fact that we don't have the jar available to us through a standard maven repository, and can't use environment variables in our `deps.edn` specifications.
+
+  Function argument types (that differ from clojure defaults):
+  os - keyword
+  TODO:
+  - Rename platform to OS throughout? (this would be clearer and there are references to screen platforms as well in the code)
+  - clarify which functions are actually used outside of this file and restructure accordingly.
+  "
+  (:require
+   [babashka.fs :as fs]
+   [cemerick.pomegranate :as pom]
+   [wolframite.runtime.system :as system])
+  (:import
+   (java.lang System)))
+
+(def ^:private jlink "SystemFiles/Links/JLink/JLink.jar") ; Expected relative path within the install directory.
+
+(defn- path--jlink
+  "The full path to jlink.
+
+  NOTE: Returns a string."
+  ([info]
+   (let [{:keys [user-paths defaults]} info
+         jpaths (keep :JLINK_JAR_PATH user-paths)]
+     (if (not-empty jpaths)
+       (first jpaths)
+       (-> defaults
+           :root
+           (fs/path jlink)
+           str)))))
+
+(defn add-jlink-to-classpath!
+  "Tries and 'throws' otherwise."
+
+  ([]
+   (let [info (system/info)
+         path (path--jlink info)]
+     (when-not (fs/exists? path)
+       (throw (ex-info (str "Unable to find JLink jar at the expected path " path
+                            " Consider setting one of the supported environment variables;"
+                            " currently: " (into [] (:user-paths info)) ".")
+                       {:os (get-in info [:defaults :os])
+                        :path path
+                        :env (:user-paths info)})))
+     (println (str "=== Adding path to classpath:" path " ==="))
+     (pom/add-classpath path))))
+
+;; ==================================================
+;; ENTRY POINT
+;; ==================================================
+(add-jlink-to-classpath!)
+;; ==================================================

--- a/src/wolframite/runtime/system.clj
+++ b/src/wolframite/runtime/system.clj
@@ -95,7 +95,7 @@
                     {:paths base-path}))))))
 
 (defn- ->os
-  "Coerces to a common os identifier or throws an 'unrecognised' error."
+  "Coerces to a common OS identifier or throws an 'unrecognised' error."
   [os]
   (cond
     (#{:linux "Linux" "linux"} os)         :linux
@@ -114,7 +114,7 @@
   (->os (System/getProperty "os.name")))
 
 (defn- choose-defaults
-  "Selects the application options according to the os, guessing the os if not provided.
+  "Selects the application options according to the OS, guessing the OS if not provided.
 
   TODO: Add the version directory type coercion here?
   "

--- a/src/wolframite/runtime/system.clj
+++ b/src/wolframite/runtime/system.clj
@@ -1,0 +1,145 @@
+(ns wolframite.runtime.system
+  "For dealing with the runtime system, primarily the operating system specific defaults."
+  (:require
+   [babashka.fs :as fs]
+   [clojure.string :as string])
+  (:import
+   (java.lang System)))
+
+(def supported-OS #{:linux :mac :windows})
+
+;; Default path information can be listed here, in order of preference.
+(def ^:private defaults
+  [{:root  "/usr/local/Wolfram/Mathematica"
+    :kernel "Executables/MathKernel"
+    :product :mathematica
+    :os :linux}
+   {:root  "/opt/Mathematica"
+    :kernel "Executables/MathKernel"
+    :product :mathematica
+    :os :linux}
+   {:root  "/usr/local/Wolfram/WolframEngine"
+    :kernel "Executables/WolframKernel"
+    :product :wolfram-engine
+    :os :linux}
+
+   {:root  "/Applications/Mathematica.app/Contents"
+    :kernel "MacOS/MathKernel"
+    :product :mathematica
+    :os :mac}
+   {:root   "/Applications/Wolfram Engine.app/Contents/Resources/Wolfram Player.app/Contents"
+    :kernel "MacOS/WolframKernel"
+    :product :wolfram-engine
+    :os :mac}
+
+   {:root "/c:/Program Files/Wolfram Research/Mathematica/"
+    :kernel "WolframKernel.exe"
+    :product :mathematica
+    :os :windows}
+   {:root "/c:/Program Files/Wolfram Research/Wolfram Engine/"
+    :kernel "MathKernel.exe"
+    :product :wolfram-engine
+    :os :windows}])
+
+(defn- user-paths
+  "The paths given via Java property or environment variables.
+
+  NOTE: These should be root directories that distinguish Mathematica or Wolfram engine files, not subdirectories. E.g.  '/usr/local/Wolfram/Mathematica'.
+
+  TODO:
+  - (jh) alternatively, support Java system properties?"
+  []
+  (let [names  ["JLINK_JAR_PATH"
+                "MATHEMATICA_INSTALL_PATH"
+                "WOLFRAM_INSTALL_PATH"]
+        method (fn [f] (-> f (nth  2) first str (string/split #"/") last))
+        fs ['(fn [name] (System/getProperty name)) '(fn [name] (System/getenv name))]]
+    (->> (map (fn [f]
+                (map (fn [name] [[(keyword name) ((eval f) name)]
+                                 [:source (method f)]])
+                     names))
+              fs)
+         (apply concat)
+         (map #(into {} %)))))
+
+(defn- version
+  "Extracts the version from a given path into a vector of numbers.
+
+  ASSUME: path node (folder) is period-separated number, e.g. 13.0.2 -> [13 0 2]
+  "
+  [version-path]
+  (-> version-path
+      fs/file-name
+      (string/split #"\.")
+      (->> (mapv parse-long))))
+
+(defn- ->version-path
+  "Detects type of path, i.e. whether or not there is a version number subdirectory, and returns the relevant one.
+
+  NOTE:
+  - Returns a string.
+  "
+  [base-path]
+
+  (let [path (when (fs/exists? base-path) (str base-path))
+        version-dir
+        (some->> path
+                 fs/list-dir
+                 (sort-by version)
+                 last
+                 str)]
+    (if version-dir version-dir
+        (if path
+          (throw
+           (ex-info (str "Could not find a Wolfram base directory (directory with numerical values separated by '.') at the given base path.")
+                    {:paths base-path}))))))
+
+(defn- ->os
+  "Coerces to a common os identifier or throws an 'unrecognised' error."
+  [os]
+  (cond
+    (#{:linux "Linux" "linux"} os)         :linux
+    (#{:osx :macos "Mac OS X" "mac"} os) :mac
+    (or (#{:win :windows} os) (string/starts-with? os "Windows")) :windows
+    :else (throw
+           (ex-info (str "Did not recognise " os " as a supported OS.")
+                    {:os os}))))
+
+(defn detect-os
+  "Tries to detect the current operating system.
+
+  Currently just checks a java property, but could search default paths in the future.
+  "
+  []
+  (->os (System/getProperty "os.name")))
+
+(defn- choose-defaults
+  "Selects the application options according to the os, guessing the os if not provided.
+
+  TODO: Add the version directory type coercion here?
+  "
+  ([]
+   (choose-defaults (detect-os)))
+
+  ([os]
+   (->> defaults
+        (filter #(= os (:os %)))
+        (filter (comp fs/exists? :root))
+        first)))
+
+(defn path--kernel
+  "Using the given base path, checks if any of the wolfram binaries can be found.
+
+  TODO: Maybe just search to see if the executable is anywhere under the given root?
+  TODO: replace filter with something that returns on first successful test.
+  "
+  ([] (path--kernel (:root (choose-defaults))))
+  ([base-path]
+   (let [path (->version-path base-path)
+         options (->> defaults
+                      (map :kernel)
+                      (map #(fs/path path %)))]
+
+     (or (-> (filter fs/exists? options)
+             first)
+         (throw (ex-info (str "Could not find a Wolfram executable at the given base path. We looked in these places: " (seq options) ".") {:paths options}))))))

--- a/src/wolframite/tools/graphics.clj
+++ b/src/wolframite/tools/graphics.clj
@@ -1,6 +1,6 @@
 (ns wolframite.tools.graphics
   "Displaying WL graphics with java.awt"
-  (:require [wolframite.jlink]
+  (:require [wolframite.runtime.jlink]
             [wolframite.core :as wl])
   (:import (com.wolfram.jlink MathCanvas KernelLink)
            (java.awt Color Frame)
@@ -56,15 +56,11 @@
   ;;
   ;; (WL :show (GeoGraphics))
 
-
-
 (comment ;; fun is good
 
   (show! canvas "GeoGraphics[]")
   (show! canvas "Graph3D[GridGraph[{3, 3, 3}, VertexLabels -> Automatic]]")
-  (show! canvas "GeoImage[Entity[\"City\", {\"NewYork\", \"NewYork\", \"UnitedStates\"}]]")
-
-  )
+  (show! canvas "GeoImage[Entity[\"City\", {\"NewYork\", \"NewYork\", \"UnitedStates\"}]]"))
 
 (comment ;; better quality images
   (import '[com.wolfram.jlink KernelLink])
@@ -78,5 +74,4 @@
                (ImageIO/read (ByteArrayInputStream. (.evaluateToImage wl/kernel-link-atom "GeoGraphics[]" (int width) (int height) 600 true)))))
 
   ;; doesn't make much difference (maybe a bit), seems like we can go lower dpi, but we already get maximum by default (?)
-
   )


### PR DESCRIPTION
Had a few extra problems (#49), and since I was in the zone, I not only fixed the optional presence of a version subdirectory, but I restructured the ns. 

I extracted all of the general functions, with renaming, to a new runtime.system ns and I moved the remaining jlink specific functionality into runtime.jlink. I Also, hopefully, updated all of the code references to jlink to use the new place. Happy to change/undo these things based on feedback. 

The new way just seems more organised to me and still works on my machines.