### PR TITLE
Fix #76 Incorrect conversion of Integer 5 to Expr

### DIFF
--- a/src/wolframite/impl/jlink_proto_impl.clj
+++ b/src/wolframite/impl/jlink_proto_impl.clj
@@ -3,10 +3,56 @@
   cannot be loaded/required until JLink is on the classpath."
   (:require [clojure.string :as str]
             [wolframite.impl.protocols :as proto])
-  (:import [com.wolfram.jlink Expr KernelLink MathCanvas MathLinkException MathLinkFactory]))
+  (:import (clojure.lang BigInt)
+           [com.wolfram.jlink Expr KernelLink MathCanvas MathLinkException MathLinkFactory]))
 
 (defn- array? [x]
-  (-> x class str (str/starts-with? "class [L")))
+  (some-> x class .isArray))
+
+(defn- make-expr [primitive-or-exprs]
+  (try
+
+    (cond
+      (sequential? primitive-or-exprs)
+      (Expr.
+        ^Expr (first primitive-or-exprs)
+        ^"[Lcom.wolfram.jlink.Expr;" (into-array Expr (rest primitive-or-exprs)))
+      ;; Here, primitive-or-exprs could be an int, a String, long[], or similar
+
+      (array? primitive-or-exprs)
+      (Expr. primitive-or-exprs)
+
+      (string? primitive-or-exprs)
+      (Expr. ^String primitive-or-exprs)
+
+      (number? primitive-or-exprs)
+      (condp = (type primitive-or-exprs)
+        Long    (Expr. ^long (.longValue primitive-or-exprs))
+        Double  (Expr. ^double (.doubleValue primitive-or-exprs))
+        Integer (Expr. ^int (.intValue primitive-or-exprs))
+        Float   (Expr. ^float (.floatValue primitive-or-exprs))
+        Short   (Expr. ^short (.shortValue primitive-or-exprs))
+        BigDecimal (Expr. ^BigDecimal primitive-or-exprs)
+        BigInt (Expr. (.toBigInteger ^BigInt primitive-or-exprs))
+        BigInteger (Expr. ^BigInteger primitive-or-exprs))
+
+      :else
+      (throw (IllegalArgumentException. (str "Unsupported primitive value of type "
+                                             (type primitive-or-exprs)
+                                             " Value " primitive-or-exprs))))
+
+    (catch Exception e
+      (throw (ex-info (str "Failed to create an expression from "
+                           primitive-or-exprs
+                           " Caused by: "
+                           (ex-message e)
+                           (when (sequential? primitive-or-exprs)
+                             " All elements in the sequence must be instances of the 'Expr' class."))
+                      {:argument primitive-or-exprs
+                       :types (if (sequential? primitive-or-exprs)
+                                (map type primitive-or-exprs)
+                                (type primitive-or-exprs))
+                       :cause e})))))
 
 (defrecord JLinkImpl [opts kernel-link-atom]
   proto/JLink
@@ -37,12 +83,7 @@
     (.terminateKernel ^KernelLink @kernel-link-atom)
     (reset! kernel-link-atom nil))
   (expr [_this primitive-or-exprs]
-    (if (sequential? primitive-or-exprs)
-      (Expr.
-        ^Expr (first primitive-or-exprs)
-        ^"[Lcom.wolfram.jlink.Expr;" (into-array Expr (rest primitive-or-exprs)))
-      ;; Here, primitive-or-exprs could be an int, a String, long[], or similar
-      (Expr. primitive-or-exprs)))
+    (make-expr primitive-or-exprs))
   (expr [_this type name]
     (Expr. ^int (case type
                   :Expr/SYMBOL  Expr/SYMBOL)

--- a/test/wolframite/core_test.clj
+++ b/test/wolframite/core_test.clj
@@ -43,5 +43,12 @@
          (eval '(-> #'w2/Plus meta :doc)))
       "Interned vars have docstrings"))
 
+(deftest bug-fixes
+  (wl/start)
+  (testing "#76 double eval of ->"
+    (is (= '(-> x 5)
+           (wl/eval (wl/eval (w/-> 'x 5))))
+        "Should not throw")))
+
 (comment
   (clojure.test/run-tests 'wolframite.core-test))


### PR DESCRIPTION
Issue: `(wl/eval (wl/eval (w/-> 'x 5)))` failed with "IllegalArgumentException: No matching ctor found for class com.wolfram.jlink.Expr" b/c at some point we tried `(Expr. 5)` where 5 was an `Integer`.

Fix: Be explicit about what types we support + manually un-box supported number types.