### PR TITLE
Work around #91, Clay/Portal preventing CLI exit

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,10 +1,9 @@
 (ns build
   "Project build config as code for clojure's tools.build"
   (:require [build-config]
-            [babashka.fs :as fs]
             [clojure.tools.build.api :as b]
-            [clojure.edn :as edn]
-            [scicloj.clay.v2.api :as clay]))
+            ;[scicloj.clay.v2.api :as clay] -> dynamic require, due to https://github.com/scicloj/clay/issues/98
+            [clojure.edn :as edn]))
 
 (def project (-> (edn/read-string (slurp "deps.edn"))
                  :aliases :neil :project))
@@ -63,8 +62,9 @@
 
 (defn build-site [opts]
   (println "Going to build docs ...")
-  (clay/make! (assoc build-config/config
+  ((requiring-resolve 'scicloj.clay.v2.api/make!)
+   (assoc build-config/config
                 :clean-up-target-dir true
                 :show false))
-  (System/exit 0) ; something keeps the JVM alive and I don't know what so kill it
+  ((requiring-resolve 'portal.runtime.jvm.launcher/stop))
   opts)

--- a/deps.edn
+++ b/deps.edn
@@ -31,11 +31,10 @@
            ;; `env CLOJARS_USERNAME=<tbd> CLOJARS_PASSWORD=<clojars-token>  clojure -T:build deploy`
            {:deps {io.github.clojure/tools.build {:git/tag "v0.10.4" :git/sha "31388ff"}
                    slipset/deps-deploy {:mvn/version "0.2.2"}
-                   babashka/fs {:mvn/version "0.5.20"}
                    org.scicloj/clay {:mvn/version "2-beta15"}
                    ;; We need wolframite + JLink to render Wolf code in the docs
                    org.scicloj/wolframite {:local/root "."}
-                   wolfram/jlink {:local/root "./symlink-jlink.jar"}}
+                   wolfram/jlink {:local/root "./symlink-jlink.jar"}} ; FYI jlink only needed for build-site
             :extra-paths ["notebooks"]
             :override-deps {io.github.nextjournal/markdown {:git/sha "6683c48dfdb23404a23057817b6ac3acf0310bca"}} ; see #wolframite/56
             :ns-default build}}}


### PR DESCRIPTION
Issue: When we require Clay, it starts a Portal server process - which keeps running and prevents the JVM from exiting.

Fix: Only require Clay for build-site, and stop portal manually

See https://github.com/scicloj/clay/issues/98