### PR TITLE
Fix #104 Add updated paths for Wolfram 14.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Wolframite is open-source and targeted at applications in scientific computing, 
 
 First, if you haven't already, install the [Clojure CLI toolchain](https://clojure.org/guides/getting_started) (homebrew is a great way to do this if you're on Mac or Linux, but you can just as easily use the installation scripts if you prefer).
 
-#### Mathematica or Wolfram Engine
+#### Wolfram (Mathematica) or Wolfram Engine
 
-Next, obviously, you'll need to ensure that you have Wolfram Engine or Mathematica installed and your license (free for W. E.) registered - make sure you can run these tools on their own _before_ trying Wolframite.
+Next, obviously, you'll need to ensure that you have Wolfram Engine or the Wolfram desktop app (formerly called Mathematica) installed and your license (free for W. E.) registered - make sure you can run these tools on their own _before_ trying Wolframite.
 
 First of all, you need to initialize a connection to a Wolfram/Mathematica kernel, like this:
 
@@ -154,6 +154,10 @@ Build the jar with `clojure -T:build jar` then deploy with
 
 Note: You need to log in to Clojars and generate a deployment token. You also need to be added to
 the SciCloj group there by an admin.
+
+Consider studying Wolfram's guide [Writing Java Programs That Use the Wolfram Language](https://reference.wolfram.com/language/JLink/tutorial/WritingJavaProgramsThatUseTheWolframLanguage.html) and 
+[WSTP and External Program Communication](https://reference.wolfram.com/language/tutorial/WSTPAndExternalProgramCommunicationOverview.html)
+when you want to dig into the JVM ↔ Wolfram communication.
 
 #### Documentation
 

--- a/src/wolframite/impl/jlink_proto_impl.clj
+++ b/src/wolframite/impl/jlink_proto_impl.clj
@@ -56,6 +56,10 @@
 (defrecord JLinkImpl [opts kernel-link-atom]
   proto/JLink
   (create-kernel-link [_this kernel-link-opts]
+    ;; BEWARE: The fact that createKernelLink() succeeds does not mean that the link is connected
+    ;; and functioning properly. There is a difference between creating a link (which involves
+    ;; setting up your side) and connecting one (which verifies that the other side is alive and well).
+    ;; WSTP will automatically try to connect it the first time you try to read or write something.
     (loop [attempts 3, wait-ms 10, orig-err nil]
       ;; Sometimes, starting a link may fail b/c the previous one
       ;; has not been shut down properly

--- a/src/wolframite/runtime/system.clj
+++ b/src/wolframite/runtime/system.clj
@@ -10,31 +10,44 @@
 
 ;; Default path information can be listed here, in order of preference.
 (def ^:private defaults
-  [{:root  "/usr/local/Wolfram/Mathematica"
+  [;; LINUX
+   {:root  "/usr/local/Wolfram/Wolfram"
+    :kernel "Executables/WolframKernel"
+    :product :wolfram ; version 14.1+
+    :os :linux}
+   {:root  "/usr/local/Wolfram/Mathematica"
     :kernel "Executables/MathKernel"
-    :product :mathematica
+    :product :mathematica ; prior to 14.1
     :os :linux}
    {:root  "/opt/Mathematica"
     :kernel "Executables/MathKernel"
-    :product :mathematica
+    :product :mathematica ; alternative location
     :os :linux}
    {:root  "/usr/local/Wolfram/WolframEngine"
     :kernel "Executables/WolframKernel"
     :product :wolfram-engine
     :os :linux}
-
+   ;; MAC
+   {:root  "/Applications/Wolfram.app/Contents"
+    :kernel "MacOS/WolframKernel"
+    :product :wolfram ; version 14.1+
+    :os :mac}
    {:root  "/Applications/Mathematica.app/Contents"
     :kernel "MacOS/MathKernel"
-    :product :mathematica
+    :product :mathematica ; prior to 14.1
     :os :mac}
    {:root   "/Applications/Wolfram Engine.app/Contents/Resources/Wolfram Player.app/Contents"
     :kernel "MacOS/WolframKernel"
     :product :wolfram-engine
     :os :mac}
-
+   ;; WINDOWS
+   {:root "/c:/Program Files/Wolfram Research/Wolfram/" ; TODO verify
+    :kernel "WolframKernel.exe" ; TODO verify
+    :product :wolfram ; version 14.1+
+    :os :windows}
    {:root "/c:/Program Files/Wolfram Research/Mathematica/"
     :kernel "WolframKernel.exe"
-    :product :mathematica
+    :product :mathematica ; prior to 14.1
     :os :windows}
    {:root "/c:/Program Files/Wolfram Research/Wolfram Engine/"
     :kernel "MathKernel.exe"


### PR DESCRIPTION
Issue: It seems that since version 14.1 there is no more a Mathematica app, only a single Wolfram desktop app, which includes Mathematica.

Fix: Add the new paths. (Not all verified yet.)