### PR TITLE
Improve failed evaluation detection, reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ However, sometimes Wolframite may fail to find the correct path automatically an
 
 ```shell
 export WOLFRAM_INSTALL_PATH=/opt/mathematica/13.1
+export WOLFRAM_INSTALL_PATH="/Applications/Wolfram Engine.app/Contents/Resources/Wolfram Player.app/Contents"
 ```
 
 ### Getting started

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.12.0-beta1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/tools.logging {:mvn/version "1.3.0"}
 
         org.scicloj/kindly {:mvn/version "4-beta5"}
@@ -26,6 +26,9 @@
                          {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
             :main-opts ["--main" "cognitect.test-runner"]
             :exec-fn cognitect.test-runner.api/test}
+
+           :jlink-jar ; useful for IntelliJ sometimes
+           {:deps {wolfram/jlink {:local/root "./symlink-jlink.jar"}}}
 
            :build ;; added by neil; 1) build with `clojure -T:build jar` then deploy with
            ;; `env CLOJARS_USERNAME=<tbd> CLOJARS_PASSWORD=<clojars-token>  clojure -T:build deploy`

--- a/src/wolframite/base/evaluate.clj
+++ b/src/wolframite/base/evaluate.clj
@@ -34,28 +34,23 @@
   {:pre [jlink-instance]}
   (assert (proto/expr? jlink-instance expr))
   (assert (proto/kernel-link? jlink-instance))
-  (let [link (proto/kernel-link jlink-instance)]
-   (if (options/flag?' (:flags opts) :serial)
-     (io!
-       (locking link
-         (doto link (.evaluate expr) (.waitForAnswer))
-         ; When eval failed b/c it needs internet but offline, still (.error link) = 0, (.errorMessage link) = "No ... problem..."
-         (.getExpr link)))
-     (let [opts' (update opts :flags conj :serial) ;; FIXME: make sure this is supposed to be `:serial`, it's what I gather from previous version of the code
-           pid-expr (evaluate (convert/convert
-                                (list 'Unique
-                                      ; Beware: technically, this is an invalid clj symbol due to the slashes:
-                                      (symbol "Wolframite/Concurrent/process")) opts')
-                              opts)]
-       ;; FIXME: debug log: "pid-expr:"
-       (evaluate (convert/convert (list '= pid-expr (list 'ParallelSubmit expr)) opts') opts)
-       (evaluate (convert/convert '(QueueRun) opts') opts)
-       (loop []
-         (let [[state result] (process-state pid-expr opts)]
-           (if (not= :finished state)
-             (do
-               (queue-run-or-wait opts)
-               (recur))
-             (do
-               (evaluate (convert/convert (list 'Remove pid-expr) opts') opts)
-               result))))))))
+  (if (options/flag?' (:flags opts) :serial)
+    (proto/evaluate! jlink-instance expr)
+    (let [opts' (update opts :flags conj :serial) ;; FIXME: make sure this is supposed to be `:serial`, it's what I gather from previous version of the code
+          pid-expr (evaluate (convert/convert
+                               (list 'Unique
+                                     ; Beware: technically, this is an invalid clj symbol due to the slashes:
+                                     (symbol "Wolframite/Concurrent/process")) opts')
+                             opts)]
+      ;; FIXME: debug log: "pid-expr:"
+      (evaluate (convert/convert (list '= pid-expr (list 'ParallelSubmit expr)) opts') opts)
+      (evaluate (convert/convert '(QueueRun) opts') opts)
+      (loop []
+        (let [[state result] (process-state pid-expr opts)]
+          (if (not= :finished state)
+            (do
+              (queue-run-or-wait opts)
+              (recur))
+            (do
+              (evaluate (convert/convert (list 'Remove pid-expr) opts') opts)
+              result)))))))

--- a/src/wolframite/impl/protocols.clj
+++ b/src/wolframite/impl/protocols.clj
@@ -10,6 +10,7 @@
   from the existing code."
   (create-kernel-link [this kernel-link-opts])
   (terminate-kernel! [this])
+  (evaluate! [this expr] "Evaluate the given JLink Expr in the kernel")
   (expr
     [this]
     [this primitive-or-exprs]
@@ -35,6 +36,8 @@
   (create-kernel-link [this kernel-link-opts]
     (throw (IllegalStateException. "JLink not loaded!")))
   (terminate-kernel! [this]
+    (throw (IllegalStateException. "JLink not loaded!")))
+  (evaluate! [this expr]
     (throw (IllegalStateException. "JLink not loaded!")))
   (expr [this expr-coll]
     (throw (IllegalStateException. "JLink not loaded!")))

--- a/src/wolframite/tools/graphics.clj
+++ b/src/wolframite/tools/graphics.clj
@@ -1,5 +1,8 @@
 (ns wolframite.tools.graphics
   "Displaying WL graphics with java.awt"
+  ;; Wolfram has You use MathCanvas when you want an AWT component and MathGraphicsJPanel when you
+  ;; want a Swing component - see https://reference.wolfram.com/language/JLink/tutorial/CallingJavaFromTheWolframLanguage.html#20608
+  ;; Notice that KernelLink also has evaluateToImage() and evaluateToTypeset() methods
   (:require [wolframite.impl.jlink-instance :as jlink-instance]
             [wolframite.impl.protocols :as proto]
             [wolframite.core :as wl])


### PR DESCRIPTION
Issue: When we ask Wolfram to do something impossible, it typically returns the input form or $Failed, so it is hard to see what was wrong. However, when evaluated in a notebook, it does print an explanation. This is however ignored by the recommended `.waitForAnswer`.

Fix: Follow the docs and add a packet listener, which captures the messages we care about in these cases (text, message) between we start eval and read the result. To make this easier, move the impl. of evaluation into a new protocol method `evaluate!` + add extracting captured messages from the listener + throw an error if the result seems to indicate a problem.

Bonus: Upgrade Clojure to stable.

# Demo

What does this look like?

```clj
(wl/eval "Subtract[1]")
Execution error (ExceptionInfo) at wolframite.impl.jlink_proto_impl.JLinkImpl/evaluate_BANG_ (jlink_proto_impl.clj:151).
Evaluation seems to have failed. Result: Subtract[1] Details: Subtract::argr: Subtract called with 1 argument; 2 arguments are expected.

(wl/eval "Get[\"/no-such-file\"]")
Execution error (ExceptionInfo) at wolframite.impl.jlink_proto_impl.JLinkImpl/evaluate_BANG_ (jlink_proto_impl.clj:151).
Evaluation seems to have failed. Result: $Failed Details: Get::noopen: Cannot open /no-such-file.

(wl/eval "Print[\"hello!\"]") ; => nil
[nREPL-session-101a2c04-a45a-4559-9cb5-319d8574a740] INFO wolframite.impl.jlink-proto-impl - Messages retrieved during evaluation: [hello!
]
```