### PR TITLE
Ensure new graphics content is displayed; only scale output supporting it

### DIFF
--- a/src/wolframite/tools/graphics.clj
+++ b/src/wolframite/tools/graphics.clj
@@ -34,8 +34,13 @@
   @default-app)
 
 (defn- fit-graphic-expr-to-frame ^String [^String wl-expr-str ^Component container]
-  (let [size (.getSize container)]
-    (str "Show[" wl-expr-str ", ImageSize -> {" (.width size) "," (.height size) "}]")))
+  (let [size (.getSize container)
+        scaled-expr
+        (format "With[{g=%s}, If[MatchQ[g, _Graphics | _Graphics3D],Show[g,ImageSize -> {%d,%d}],g]]" ; should include also Image | Image3D ?
+                wl-expr-str
+                (.width size)
+                (.height size))]
+    scaled-expr))
 
 (defn set-resize-timer [{:keys [^JFrame frame, ^MathGraphicsJPanel math] :as _app} wl-expr-str]
   (doseq [l (.getComponentListeners frame)]

--- a/src/wolframite/tools/graphics.clj
+++ b/src/wolframite/tools/graphics.clj
@@ -11,7 +11,7 @@
     (java.awt.event ActionListener ComponentAdapter MouseAdapter)
     (java.awt.image BufferedImage)
     (javax.imageio ImageIO)
-    [javax.swing JFileChooser JFrame JMenuItem JOptionPane JPanel JPopupMenu JScrollPane SwingUtilities Timer]))
+    [javax.swing JFileChooser JFrame JMenuItem JOptionPane JPanel JPopupMenu JScrollPane JViewport SwingUtilities Timer]))
 
 (defonce ^:private default-app (promise))
 
@@ -34,7 +34,10 @@
   @default-app)
 
 (defn- fit-graphic-expr-to-frame ^String [^String wl-expr-str ^Component container]
-  (let [size (.getSize container)
+  (let [parent (.getParent container)
+        size (if (instance? JViewport parent)
+               (.getExtentSize ^JViewport parent)
+               (.getSize container))
         scaled-expr
         (format "With[{g=%s}, If[MatchQ[g, _Graphics | _Graphics3D],Show[g,ImageSize -> {%d,%d}],g]]" ; should include also Image | Image3D ?
                 wl-expr-str
@@ -194,14 +197,6 @@
   (show! "Plot[Sin[x], {x, 0, 6 Pi}]")
   (show! "Plot[Sin[x], {x, 0, 4 Pi}]")
   (show! '(Plot (Sin x) [x 0 (* 6 Math/PI)]))
-
-  (def *G *1)
-  (.pack (:frame *G))
-  (.repaint (:frame *G))
-  (.repaint (.getParent (:math *G)))
-  (.repaint (:math *G))
-
-  (:math *G)
 
   (def win (show! "Plot[Sin[x], {x, 0, 2 Pi}]"))
   (show! "Plot[Cos[x], {x, 0, 2 Pi}]" win)


### PR DESCRIPTION
# 1. Fix 152: Ensure new graphics content is displayed

Problem: Swing is not thread-safe, and according to internets, all changes to its state - i.e. components - need to be done on the Event Dispatch Thread. That is likely the reason why sometimes, calling `show!` did not update the already open window, or why it "flickered," showing briefly the new content than reverting to the old one.

Fix: Run all the component-changing code inside E.D.T., via `SwingUtilities/invokeAndWait`.

# 2. Fix resizing: setSize first, then setMathCmd

I have finally figured out the correct incantation to make resizing work correctly. `Show[]` has nothing to do with it. What we must do is `math.setSize` _first_ and `.setMathCommand` _second_.

Also: Factor out `ensure-math-sized-to-frame!`.