### PR TITLE
Fix #124 Add support for RuleDelayed in maps

### DIFF
--- a/notebooks/clojure_primer/index.clj
+++ b/notebooks/clojure_primer/index.clj
@@ -148,6 +148,14 @@ cases, your \"program\" is running all the time and you keep adding to it, build
 
 You can read more on Clojure's take on [interactive development](https://clojure.org/guides/repl/introduction) a.k.a. REPL-driven development on the official Clojure website.")
 
+(k/md "## Error handling
+
+In some cases, when evaluation fails, Wolframite throws a Java exception. You can use the handy Clojure functions `ex-message` and `ex-data` to learn more about the problem:
+")
+(def fake-exception (ex-info "Something blew up" {:some-details "It was bad"}))
+(ex-message fake-exception)
+(ex-data fake-exception)
+
 (k/md "## Resources for further learning
 
 * The [Clojure cheatsheat](http://jafingerhut.github.io/cheatsheet/clojuredocs/cheatsheet-tiptip-cdocs-summary.html)\nis a good place to look for functions.

--- a/src/wolframite/impl/error_detection.clj
+++ b/src/wolframite/impl/error_detection.clj
@@ -1,0 +1,13 @@
+(ns wolframite.impl.error-detection)
+
+(defn error-message-expr
+  "Does the result represent a (delayed) error message template, which we can evaluate
+  to get the actual message?"
+  ;; Ex.: Association[RuleDelayed["MessageTemplate", MessageName[Interpreter, "noknow"]]]
+  [clj-result]
+  (and (map? clj-result)
+       (= 1 (count clj-result))
+       (= "MessageTemplate" (ffirst clj-result))
+       (let [{:strs [MessageTemplate]} clj-result]
+         (when (-> MessageTemplate meta :wolfram/delayed)
+           MessageTemplate))))

--- a/src/wolframite/impl/error_detection.clj
+++ b/src/wolframite/impl/error_detection.clj
@@ -1,4 +1,12 @@
-(ns wolframite.impl.error-detection)
+(ns wolframite.impl.error-detection
+  "Centralize Wolfram-related error handling"
+  (:require [clojure.tools.logging :as log]
+            [wolframite.impl.protocols :as proto]))
+
+;; Wolfram sometimes indicates failure by returning the symbol $Failed, at least in some cases
+(defonce ^:private failed-expr-p
+         ;; Delay b/c we need to wait until JLink is loaded
+         (delay (proto/atomic-expr proto/type-symbol "$Failed")))
 
 (defn error-message-expr
   "Does the result represent a (delayed) error message template, which we can evaluate
@@ -11,3 +19,33 @@
        (let [{:strs [MessageTemplate]} clj-result]
          (when (-> MessageTemplate meta :wolfram/delayed)
            MessageTemplate))))
+
+(defn ensure-no-eval-error [expr eval-result eval-messages]
+  (let [messages-text (mapv :content eval-messages)]
+    (cond
+      (and (seq eval-messages)
+           (or (= eval-result @failed-expr-p)
+               (= eval-result expr)))
+      ;; If input expr == output expr, this usually means the evaluation failed
+      ;; (or there was nothing to do); if there are also any extra text/message packets
+      ;; then it most likely has failed, and those messages explain what was wrong
+      (throw (ex-info (str "Evaluation seems to have failed. Result: "
+                           eval-result
+                           " Details: "
+                           (cond-> messages-text
+                                   (= 1 (count messages-text))
+                                   first))
+                      {:expr expr
+                       :messages eval-messages
+                       :result eval-result}))
+
+      (= eval-result @failed-expr-p) ; but no messages
+      (throw (ex-info (str "Evaluation has failed. Result: "
+                           eval-result
+                           " No details available.")
+                      {:expr expr :result eval-result}))
+
+      :else
+      (do (when (seq eval-messages)
+            (log/info "Messages retrieved during evaluation:" messages-text))
+          eval-result))))

--- a/src/wolframite/impl/protocols.clj
+++ b/src/wolframite/impl/protocols.clj
@@ -40,6 +40,7 @@
   (head [this] "Same as .head, i.e. the first part of the expression list")
   (head-sym-str [this] "Returns the head as a string when it is a Symbol, otherwise nil")
   (list? [this])
+  (atomic-expr [type-kwd value] "Returns a new jlink Expr of the given type, passing the constructor the `value` argument")
   (number? [this] "Is this a number? See also [[as-number]]"))
 
 (defprotocol JLink

--- a/src/wolframite/impl/protocols.clj
+++ b/src/wolframite/impl/protocols.clj
@@ -62,7 +62,7 @@
                            of 1+ jlink Exprs (which is interpreted as a fn call).
     * [type name] where type=:Expr/SYMBOL - create a Wolfram symbol")
   (->expr [this obj] "Turn the given obj into a jlink Expr via the loopback link 🤷")
-  (expr? [this x])
+  (expr? [this expr] "Is `expr` an instance of jlink Expr?")
   (expr-element-type [this container-type expr])
   (->expr-type [this type-kw])
   (kernel-link [_this])

--- a/test/wolframite/base/parse_test.clj
+++ b/test/wolframite/base/parse_test.clj
@@ -37,7 +37,18 @@
            (parse/parse (convert/convert {"a" 1} nil) nil)))
     (is (= {}
            (parse/parse (convert/convert {} nil) nil))
-        "Empty maps work too")))
+        "Empty maps work too"))
+  (testing "RuleDelayed"
+    ;; Some errors are returned as a MessageTemplate -> delayed call to get the message name, f.ex.
+    ;; `(wl/! (list (w/Interpreter "City") "San Francisco, US"))` while offline.
+    (let [parsed (-> (w/Association (w/RuleDelayed "MessageTemplate" (w/MessageName w/Interpreter "noknow")))
+                     (convert/convert nil)
+                     (parse/parse nil))]
+      (is (= {"MessageTemplate" '(MessageName Interpreter "noknow")}
+             parsed)
+          "We can parse RuleDelayed")
+      (is (= true
+             (-> parsed vals first meta :wolfram/delayed))))))
 
 (deftest custom-parse
   (wl/start!)

--- a/test/wolframite/core_test.clj
+++ b/test/wolframite/core_test.clj
@@ -1,13 +1,14 @@
 (ns wolframite.core-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer :all]
             [wolframite.core :as wl]
             [wolframite.flags :as flags]
             [wolframite.impl.wolfram-syms.wolfram-syms :as wolfram-syms]
             [wolframite.wolfram :as w :refer :all
              :exclude [* + - -> / < <= = == > >= fn
-                       Byte Character Integer Number Short String Thread]]
+                       Byte Character Integer Number Short String Thread Pattern]]
             [wolframite.wolfram :as w])
-  (:import (clojure.lang ExceptionInfo)))
+  (:import (clojure.lang ExceptionInfo)
+           (java.util.regex Pattern)))
 
 ;; * Basic Sanity Checks
 
@@ -132,7 +133,16 @@
            (wl/eval (w/Map (w/fn [x]
                              (w/Map (w/fn [x] (w/Minus x)) x))
                            [[1 2]])))
-        "Two nested uses of w/fn with arg shadowing should work")))
+        "Two nested uses of w/fn with arg shadowing should work"))
+  (testing "RuleDelayed errors"
+    ;; Some errors are returned as a MessageTemplate -> delayed call to get the message name, f.ex.
+    ;; `(wl/! (list (w/Interpreter "City") "San Francisco, US"))` while offline.
+    ;; Let's simulate that by evaluating what Wolfram would have returned
+    (is (thrown-with-msg?
+          ExceptionInfo
+          (re-pattern (Pattern/quote "The Wolfram Knowledgebase is not available. Try again later."))
+          (wl/eval (Association (RuleDelayed "MessageTemplate" (MessageName Interpreter "noknow")))))
+        "RuleDelayed MessageTemplate responses are turned into exceptions")))
 
 (deftest bug-fixes
   (wl/start!)


### PR DESCRIPTION
Context:
Sometimes, Wolfram returns an error in the form of a RuleDelayed from `"MessageTemplate"` to an expression to get a human-friendly message. F.ex. evaluating `(list (w/Interpreter "City") "San Francisco, US")` while offline returns `Association[RuleDelayed["MessageTemplate", MessageName[Interpreter, "noknow"]]]`. We should do better than throw a parse exception. It has been decided to return the delayed expression as-is and leave it to the user to evaluate it (since calling eval during parsing is ugly).
    
Action:
Parse RuleDelayed just as Rule, only add a metadata :wolfram/delayed, for user's information.